### PR TITLE
Expand home dirs for loadf and envvar file

### DIFF
--- a/confidence.py
+++ b/confidence.py
@@ -223,7 +223,7 @@ def loadf(*fnames):
         with open(fname, 'r') as fp:
             return yaml.load(fp.read())
 
-    return Configuration(*(readf(fname) for fname in fnames))
+    return Configuration(*(readf(path.expanduser(fname)) for fname in fnames))
 
 
 def loads(*strings):

--- a/confidence.py
+++ b/confidence.py
@@ -272,16 +272,15 @@ def read_envvar_file(name):
 
     :param name: environment variable prefix to look for (without the
         ``_CONFIG_FILE``)
-    :return: a nested (possibly empty) `dict` with values read from file
+    :return: a `.Configuration`, possibly `.NotConfigured`
     """
     envvar_file = environ.get('{}_config_file'.format(name).upper())
     if envvar_file:
         # envvar set, load value as file
-        with open(envvar_file) as fp:
-            return yaml.load(fp)
+        return loadf(envvar_file)
     else:
         # envvar not set, return an empty source
-        return {}
+        return NotConfigured
 
 
 # ordered sequence of name templates to load, in increasing significance

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -90,6 +90,15 @@ def test_loadf_multiple():
                          path.join(test_files, 'config.yaml')))
 
 
+def test_loadf_home():
+    with patch('confidence.path') as mocked_path:
+        # actual expanded home directory not under test, verify that it was called
+        mocked_path.expanduser.return_value = path.join(test_files, 'config.yaml')
+        _assert_values(loadf('~/config.yaml'))
+
+    mocked_path.expanduser.assert_called_once_with('~/config.yaml')
+
+
 def test_load_name_single():
     test_path = path.join(test_files, '{name}.{extension}')
 


### PR DESCRIPTION
`loadf(~/project.yaml)` would attempt to open that exact file. Can't think of a use case where the result of expanding ~-like things to user paths is not the caller's intention.

By having the envvar config *file* loader just call `loadf`, `PROJECT_CONFIG_FILE=~/project.yaml` will also expand the user and read `/home/mommy/project.yaml`.