### PR TITLE
Load form XDG-specified directories

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,12 @@ defining defaults or reading from multiple files:
 
     # confidence provides a convenient way of using this kind of precedence,
     # letting 'more local' files take precedence over system-wide sources
-    # load_name will attempt to load
+    # load_name will attempt to load the following files, skipping ones that
+    # don't exist (see XDG spec for *-marked entries, confidence will read
+    # $XDG_CONFIG_DIRS and $XDG_CONFIG_HOME):
+    # - /etc/xdg/app.yaml   (*)
     # - /etc/app.yaml
+    # - ~/.config/app.yaml  (*)
     # - ~/.app.yaml
     # - ./app.yaml
     configuration = confidence.load_name('app')

--- a/confidence.py
+++ b/confidence.py
@@ -252,7 +252,7 @@ def read_xdg_config_home(name, extension):
     if not config_home:
         # XDG spec: "If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used."
         # see https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html
-        config_home = path.join(environ.get('HOME'), '.config')
+        config_home = path.expanduser('~/.config')
 
     # expand to full path to configuration file in XDG config path
     config_path = path.join(config_home, '{name}.{extension}'.format(name=name, extension=extension))

--- a/confidence.py
+++ b/confidence.py
@@ -252,7 +252,7 @@ def read_xdg_config_home(name, extension):
     if not config_home:
         # XDG spec: "If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used."
         # see https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html
-        config_home = path.expandvars('${HOME}/.config')
+        config_home = path.join(environ.get('HOME'), '.config')
 
     # expand to full path to configuration file in XDG config path
     config_path = path.join(config_home, '{name}.{extension}'.format(name=name, extension=extension))

--- a/confidence.py
+++ b/confidence.py
@@ -305,8 +305,7 @@ def read_envvars(name, extension):
 
     :param name: environment variable prefix to look for (without the ``_``)
     :param extension: *(unused)*
-    :return: a nested (possibly empty) `dict` with values read from
-        environment variables
+    :return: a `.Configuration` instance, possibly `.NotConfigured`
     """
     prefix = '{}_'.format(name)
     prefix_len = len(prefix)
@@ -317,8 +316,11 @@ def read_envvars(name, extension):
               # TODO: document ignoring envvar_file
               if var.lower().startswith(prefix) and var.lower() != envvar_file}
     # TODO: envvar values can only be str, how do we configure non-str values?
-    # provide it as a nested dict, treating _'s as separators, FOO_NS_KEY=bar resulting in {'ns': {'key': 'bar'}}
-    return _split_keys(values, separator='_')
+    if not values:
+        return NotConfigured
+
+    # treat _'s as separators, FOO_NS_KEY=bar resulting in {'ns': {'key': 'bar'}}
+    return Configuration(values, separator='_')
 
 
 def read_envvar_file(name, extension):

--- a/confidence.py
+++ b/confidence.py
@@ -237,7 +237,7 @@ def loads(*strings):
     return Configuration(*(yaml.load(string) for string in strings))
 
 
-def read_envvars(name):
+def read_envvars(name, extension):
     """
     Read environment variables starting with ``NAME_``, where subsequent
     underscores are interpreted as namespaces.
@@ -249,6 +249,7 @@ def read_envvars(name):
         `str` instances.
 
     :param name: environment variable prefix to look for (without the ``_``)
+    :param extension: *(unused)*
     :return: a nested (possibly empty) `dict` with values read from
         environment variables
     """
@@ -265,13 +266,14 @@ def read_envvars(name):
     return _split_keys(values, separator='_')
 
 
-def read_envvar_file(name):
+def read_envvar_file(name, extension):
     """
     Read values from a file provided as a environment variable
     ``NAME_CONFIG_FILE``.
 
     :param name: environment variable prefix to look for (without the
         ``_CONFIG_FILE``)
+    :param extension: *(unused)*
     :return: a `.Configuration`, possibly `.NotConfigured`
     """
     envvar_file = environ.get('{}_config_file'.format(name).upper())
@@ -312,7 +314,7 @@ def load_name(*names, load_order=LOAD_ORDER, extension='yaml'):
         # /etc/foo.yaml before /etc/bar.yaml, but both of them before ~/.foo.yaml and ~/.bar.yaml
         for source, name in product(load_order, names):
             if callable(source):
-                yield source(name)
+                yield source(name, extension)
             else:
                 # expand user to turn ~/.name.yaml into /home/user/.name.yaml
                 candidate = path.expanduser(source.format(name=name, extension=extension))

--- a/confidence.py
+++ b/confidence.py
@@ -237,6 +237,17 @@ def loads(*strings):
     return Configuration(*(yaml.load(string) for string in strings))
 
 
+def read_xdg_config_home(name, extension):
+    config_home = environ.get('XDG_CONFIG_HOME')
+    if config_home:
+        config_path = path.join(path.expanduser(config_home),
+                                '{name}.{extension}'.format(name=name, extension=extension))
+        if path.exists(config_path):
+            return loadf(config_path)
+
+    return NotConfigured
+
+
 def read_envvars(name, extension):
     """
     Read environment variables starting with ``NAME_``, where subsequent
@@ -288,6 +299,7 @@ def read_envvar_file(name, extension):
 # ordered sequence of name templates to load, in increasing significance
 LOAD_ORDER = (
     '/etc/{name}.{extension}',
+    read_xdg_config_home,
     '~/.{name}.{extension}',
     './{name}.{extension}',
     read_envvar_file,

--- a/confidence.py
+++ b/confidence.py
@@ -255,8 +255,7 @@ def read_xdg_config_home(name, extension):
         config_home = path.expandvars('${HOME}/.config')
 
     # expand to full path to configuration file in XDG config path
-    config_path = path.join(path.expanduser(config_home),
-                            '{name}.{extension}'.format(name=name, extension=extension))
+    config_path = path.join(config_home, '{name}.{extension}'.format(name=name, extension=extension))
     if path.exists(config_path):
         return loadf(config_path)
 

--- a/confidence.py
+++ b/confidence.py
@@ -238,6 +238,15 @@ def loads(*strings):
 
 
 def read_xdg_config_home(name, extension):
+    """
+    Read from file found in XDG-specified configuration home directory,
+    expanding to ``${HOME}/.config/name.extension`` by default. Depends on
+    ``XDG_CONFIG_HOME`` or ``HOME`` environment variables.
+
+    :param name: application or configuration set name
+    :param extension: file extension to look for
+    :return: a `.Configuration` instance, possibly `.NotConfigured`
+    """
     # find optional value of ${XDG_CONFIG_HOME}
     config_home = environ.get('XDG_CONFIG_HOME')
     if not config_home:

--- a/confidence.py
+++ b/confidence.py
@@ -238,12 +238,18 @@ def loads(*strings):
 
 
 def read_xdg_config_home(name, extension):
+    # find optional value of ${XDG_CONFIG_HOME}
     config_home = environ.get('XDG_CONFIG_HOME')
-    if config_home:
-        config_path = path.join(path.expanduser(config_home),
-                                '{name}.{extension}'.format(name=name, extension=extension))
-        if path.exists(config_path):
-            return loadf(config_path)
+    if not config_home:
+        # XDG spec: "If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used."
+        # see https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html
+        config_home = path.expandvars('${HOME}/.config')
+
+    # expand to full path to configuration file in XDG config path
+    config_path = path.join(path.expanduser(config_home),
+                            '{name}.{extension}'.format(name=name, extension=extension))
+    if path.exists(config_path):
+        return loadf(config_path)
 
     return NotConfigured
 

--- a/confidence.py
+++ b/confidence.py
@@ -286,10 +286,10 @@ def read_xdg_config_home(name, extension):
 
     # expand to full path to configuration file in XDG config path
     config_path = path.join(config_home, '{name}.{extension}'.format(name=name, extension=extension))
-    if path.exists(config_path):
-        return loadf(config_path)
+    if not path.exists(config_path):
+        return NotConfigured
 
-    return NotConfigured
+    return loadf(config_path)
 
 
 def read_envvars(name, extension):

--- a/confidence.py
+++ b/confidence.py
@@ -238,13 +238,26 @@ def loads(*strings):
 
 
 def read_xdg_config_dirs(name, extension):
+    """
+    Read from files found in XDG-specified system-wide configuration paths,
+    defaulting to ``/etc/xdg``. Depends on ``XDG_CONFIG_DIRS`` environment
+    variable.
+
+    :param name: application or configuration set name
+    :param extension: file extension to look for
+    :return: a `.Configuration` instance with values read from XDG-specified
+        directories
+    """
+    # find optional value of ${XDG_CONFIG_DIRS}
     config_dirs = environ.get('XDG_CONFIG_DIRS')
     if config_dirs:
         # PATH-like env vars operate in decreasing precedence, reverse this path set to mimic the end result
         config_dirs = reversed(config_dirs.split(path.pathsep))
     else:
+        # XDG spec: "If $XDG_CONFIG_DIRS is either not set or empty, a value equal to /etc/xdg should be used."
         config_dirs = ['/etc/xdg']
 
+    # collect existing files in the config dirs
     hits = []
     for config_dir in config_dirs:
         candidate = path.join(config_dir, '{name}.{extension}'.format(name=name, extension=extension))

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,7 +1,8 @@
 from os import path
 from unittest.mock import call, patch
 
-from confidence import Configuration, load, load_name, loadf, loads, NotConfigured, read_envvar_file, read_envvars, read_xdg_config_home
+from confidence import Configuration, load, load_name, loadf, loads, NotConfigured
+from confidence import read_envvar_file, read_envvars, read_xdg_config_dirs, read_xdg_config_home
 
 
 test_files = path.join(path.dirname(__file__), 'files')
@@ -145,6 +146,8 @@ def test_load_name_order():
         assert len(load_name('foo', 'bar')) == 0
 
     mocked_path.exists.assert_has_calls([
+        call('/etc/xdg/foo.yaml'),
+        call('/etc/xdg/bar.yaml'),
         call('/etc/foo.yaml'),
         call('/etc/bar.yaml'),
         call('/home/user/.config/foo.yaml'),
@@ -153,6 +156,44 @@ def test_load_name_order():
         call('/home/user/.bar.yaml'),
         call('./foo.yaml'),
         call('./bar.yaml'),
+    ], any_order=False)
+
+
+def test_load_name_xdg_config_dirs():
+    env = {
+        'XDG_CONFIG_DIRS': '/etc/xdg-desktop/:/etc/not-xdg',
+    }
+
+    with patch('confidence.path') as mocked_path, patch('confidence.environ', env):
+        # hard-code path separator, unmock join
+        mocked_path.pathsep = ':'
+        mocked_path.join.side_effect = path.join
+        # avoid actually opening files that might unexpectedly exist
+        mocked_path.exists.return_value = False
+
+        assert len(load_name('foo', 'bar', load_order=(read_xdg_config_dirs,))) == 0
+
+    mocked_path.exists.assert_has_calls([
+        # this might not be ideal (/etc/not-xdg should maybe show up twice first), but also not realistic…
+        call('/etc/not-xdg/foo.yaml'),
+        call('/etc/xdg-desktop/foo.yaml'),
+        call('/etc/not-xdg/bar.yaml'),
+        call('/etc/xdg-desktop/bar.yaml'),
+    ], any_order=False)
+
+
+def test_load_name_xdg_config_dirs_fallback():
+    with patch('confidence.path') as mocked_path, patch('confidence.loadf') as mocked_loadf, patch('confidence.environ', {}):
+        # hard-code path separator, unmock join
+        mocked_path.pathsep = ':'
+        mocked_path.join.side_effect = path.join
+        mocked_path.exists.return_value = True
+
+        assert len(load_name('foo', 'bar', load_order=(read_xdg_config_dirs,))) == 0
+
+    mocked_loadf.assert_has_calls([
+        call('/etc/xdg/foo.yaml'),
+        call('/etc/xdg/bar.yaml'),
     ], any_order=False)
 
 
@@ -186,7 +227,6 @@ def test_load_name_xdg_config_home_fallback():
         # hard-code user-expansion, unmock join
         mocked_path.expanduser.side_effect = _patched_expanduser
         mocked_path.join.side_effect = path.join
-        # avoid actually opening files that might unexpectedly exist
         mocked_path.exists.return_value = True
         mocked_loadf.return_value = NotConfigured
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -127,7 +127,11 @@ def test_load_name_multiple():
 
 
 def test_load_name_order():
-    with patch('confidence.path') as mocked:
+    env = {
+        'HOME': '/home/user'
+    }
+
+    with patch('confidence.path') as mocked, patch('confidence.environ', env):
         mocked.expanduser.return_value = mocked
         # avoid actually opening files that might unexpectedly exist
         mocked.exists.return_value = False


### PR DESCRIPTION
Typically defaulting to `~/.config/`, the [XDG spec](https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html) has a default place to put user configuration. There's also `${XDG_CONFIG_DIRS}`, that's been added as well in the meantime.

- [x] test in the real world
- [x] fix existing tests not expecting current edits in the load order
- [x] add tests for new loader
- [x] add support for `${XDG_CONFIG_DIRS}`