### PR TITLE
Enable ignoring missing files for loadf (defaults unchanged)

### DIFF
--- a/confidence.py
+++ b/confidence.py
@@ -116,8 +116,9 @@ class Configuration(Mapping):
 
         self._source = {}
         for source in sources:
-            # merge values from source into self._source, overwriting any corresponding keys
-            _merge(self._source, _split_keys(source, separator=self._separator), conflict=_Conflict.overwrite)
+            if source:
+                # merge values from source into self._source, overwriting any corresponding keys
+                _merge(self._source, _split_keys(source, separator=self._separator), conflict=_Conflict.overwrite)
 
     def get(self, path, default=_NoDefault, as_type=None):
         """

--- a/confidence.py
+++ b/confidence.py
@@ -265,14 +265,10 @@ def read_xdg_config_dirs(name, extension):
         # XDG spec: "If $XDG_CONFIG_DIRS is either not set or empty, a value equal to /etc/xdg should be used."
         config_dirs = ['/etc/xdg']
 
-    # collect existing files in the config dirs
-    hits = []
-    for config_dir in config_dirs:
-        candidate = path.join(config_dir, '{name}.{extension}'.format(name=name, extension=extension))
-        if path.exists(candidate):
-            hits.append(candidate)
-
-    return loadf(*hits)
+    # load a file from all config dirs, default to NotConfigured
+    fname = '{name}.{extension}'.format(name=name, extension=extension)
+    return loadf(*(path.join(config_dir, fname) for config_dir in config_dirs),
+                 default=NotConfigured)
 
 
 def read_xdg_config_home(name, extension):
@@ -293,11 +289,8 @@ def read_xdg_config_home(name, extension):
         config_home = path.expanduser('~/.config')
 
     # expand to full path to configuration file in XDG config path
-    config_path = path.join(config_home, '{name}.{extension}'.format(name=name, extension=extension))
-    if not path.exists(config_path):
-        return NotConfigured
-
-    return loadf(config_path)
+    return loadf(path.join(config_home, '{name}.{extension}'.format(name=name, extension=extension)),
+                 default=NotConfigured)
 
 
 def read_envvars(name, extension):
@@ -369,10 +362,7 @@ def read_envvar_dir(envvar, name, extension):
 
     # envvar is set, construct full file path, expanding user to allow the envvar containing a value like ~/config
     config_path = path.join(path.expanduser(config_dir), '{name}.{extension}'.format(name=name, extension=extension))
-    if not path.exists(config_path):
-        return NotConfigured
-
-    return loadf(config_path)
+    return loadf(config_path, default=NotConfigured)
 
 
 # ordered sequence of name templates to load, in increasing significance

--- a/confidence.py
+++ b/confidence.py
@@ -219,7 +219,7 @@ def loadf(*fnames, default=_NoDefault):
 
     :param fnames: name of the files to ``open()``
     :param default: `dict` or `.Configuration` to use when a file does not
-        exist (default is to raise an error)
+        exist (default is to raise a `FileNotFoundError`)
     :return: a `.Configuration` instance providing values from *fnames*
     :rtype: `.Configuration`
     """

--- a/confidence.py
+++ b/confidence.py
@@ -213,17 +213,23 @@ def load(*fps):
     return Configuration(*(yaml.load(fp.read()) for fp in fps))
 
 
-def loadf(*fnames):
+def loadf(*fnames, default=_NoDefault):
     """
     Read a `.Configuration` instance from named files.
 
     :param fnames: name of the files to ``open()``
+    :param default: `dict` or `.Configuration` to use when a file does not
+        exist (default is to raise an error)
     :return: a `.Configuration` instance providing values from *fnames*
     :rtype: `.Configuration`
     """
     def readf(fname):
-        with open(fname, 'r') as fp:
-            return yaml.load(fp.read())
+        if default is _NoDefault or path.exists(fname):
+            # (attempt to) open fname if it exists OR if we're expected to raise an error on a missing file
+            with open(fname, 'r') as fp:
+                return yaml.load(fp.read())
+        else:
+            return default
 
     return Configuration(*(readf(path.expanduser(fname)) for fname in fnames))
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -174,6 +174,7 @@ def test_load_name_xdg_config_dirs():
 
     with patch('confidence.path') as mocked_path, patch('confidence.environ', env):
         # hard-code path separator, unmock join
+        mocked_path.expanduser.side_effect = _patched_expanduser
         mocked_path.pathsep = ':'
         mocked_path.join.side_effect = path.join
         # avoid actually opening files that might unexpectedly exist
@@ -193,6 +194,7 @@ def test_load_name_xdg_config_dirs():
 def test_load_name_xdg_config_dirs_fallback():
     with patch('confidence.path') as mocked_path, patch('confidence.loadf') as mocked_loadf, patch('confidence.environ', {}):
         # hard-code path separator, unmock join
+        mocked_path.expanduser.side_effect = _patched_expanduser
         mocked_path.pathsep = ':'
         mocked_path.join.side_effect = path.join
         mocked_path.exists.return_value = True
@@ -200,8 +202,8 @@ def test_load_name_xdg_config_dirs_fallback():
         assert len(load_name('foo', 'bar', load_order=(read_xdg_config_dirs,))) == 0
 
     mocked_loadf.assert_has_calls([
-        call('/etc/xdg/foo.yaml'),
-        call('/etc/xdg/bar.yaml'),
+        call('/etc/xdg/foo.yaml', default=NotConfigured),
+        call('/etc/xdg/bar.yaml', default=NotConfigured),
     ], any_order=False)
 
 
@@ -241,8 +243,8 @@ def test_load_name_xdg_config_home_fallback():
         assert len(load_name('foo', 'bar', load_order=(read_xdg_config_home,))) == 0
 
     mocked_loadf.assert_has_calls([
-        call('/home/user/.config/foo.yaml'),
-        call('/home/user/.config/bar.yaml'),
+        call('/home/user/.config/foo.yaml', default=NotConfigured),
+        call('/home/user/.config/bar.yaml', default=NotConfigured),
     ], any_order=False)
 
 
@@ -317,8 +319,8 @@ def test_load_name_envvar_dir():
         assert len(load_name('foo', 'bar', load_order=load_order)) == 0
 
     mocked_loadf.assert_has_calls([
-        call('C:/ProgramData/foo.yaml'),
-        call('C:/ProgramData/bar.yaml'),
-        call('D:/Users/user/AppData/Roaming/foo.yaml'),
-        call('D:/Users/user/AppData/Roaming/bar.yaml'),
+        call('C:/ProgramData/foo.yaml', default=NotConfigured),
+        call('C:/ProgramData/bar.yaml', default=NotConfigured),
+        call('D:/Users/user/AppData/Roaming/foo.yaml', default=NotConfigured),
+        call('D:/Users/user/AppData/Roaming/bar.yaml', default=NotConfigured),
     ], any_order=False)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36
+envlist = py34,py35,py36,py37
 skip_missing_interpreters = True
 
 [flake8]


### PR DESCRIPTION
- new keyword argument `default` for `loadf`, defaulting to `_NoDefault`;
- take old code path if `default=_NoDefault` *or* file argument exists;
- `return default` otherwise;
- change calls to `loadf` following `path.exists` calls to use `loadf` with `default=NotConfigured`;