### PR TITLE
Fix yaml.load returning None for documents without content

### DIFF
--- a/confidence.py
+++ b/confidence.py
@@ -227,7 +227,8 @@ def loadf(*fnames, default=_NoDefault):
         if default is _NoDefault or path.exists(fname):
             # (attempt to) open fname if it exists OR if we're expected to raise an error on a missing file
             with open(fname, 'r') as fp:
-                return yaml.load(fp.read())
+                # default to empty dict, yaml.load will return None for an empty document
+                return yaml.load(fp.read()) or {}
         else:
             return default
 

--- a/confidence.py
+++ b/confidence.py
@@ -410,8 +410,6 @@ def load_name(*names, load_order=LOAD_ORDER, extension='yaml'):
             else:
                 # expand user to turn ~/.name.yaml into /home/user/.name.yaml
                 candidate = path.expanduser(source.format(name=name, extension=extension))
-                if path.exists(candidate):
-                    with open(candidate, 'r') as fd:
-                        yield yaml.load(fd.read())
+                yield loadf(candidate, default=NotConfigured)
 
     return Configuration(*generate_sources())

--- a/tests/files/comments.yaml
+++ b/tests/files/comments.yaml
@@ -1,0 +1,3 @@
+# yaml file with just comments
+
+# yes, multiple

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -126,6 +126,17 @@ def test_loadf_missing():
             loadf('/path/to/file')
 
 
+def test_loadf_empty():
+    assert len(loadf(path.join(test_files, 'empty.yaml'))) == 0
+    assert len(loadf(path.join(test_files, 'comments.yaml'))) == 0
+    assert len(loadf(path.join(test_files, 'empty.yaml'),
+                     path.join(test_files, 'comments.yaml'))) == 0
+
+    _assert_values(loadf(path.join(test_files, 'empty.yaml'),
+                         path.join(test_files, 'config.yaml'),
+                         path.join(test_files, 'comments.yaml')))
+
+
 def test_load_name_single():
     test_path = path.join(test_files, '{name}.{extension}')
 


### PR DESCRIPTION
Fix for #23, default to empty dict for falsy return values of `yaml.load`. Fix located in `loadf`, `load_name` now calling `loadf` to simplify implementation.