### PR TITLE
Enable escaping underscores in environment variables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+development (master)
+--------------------
+
+- Enable escaping underscores in environment variables (``NAME_FOO__BAR`` results in ``config.foo_bar``)
+
 0.3 (2018-05-24)
 ----------------
 

--- a/confidence.py
+++ b/confidence.py
@@ -298,7 +298,10 @@ def read_xdg_config_home(name, extension):
 def read_envvars(name, extension):
     """
     Read environment variables starting with ``NAME_``, where subsequent
-    underscores are interpreted as namespaces.
+    underscores are interpreted as namespaces. Underscores can be retained as
+    namespaces by doubling them up, e.g. ``NAME_SPA__CE_KEY`` would be
+    accessible in the resulting `.Configuration` as
+    ``c.spa_ce.key``, where ``c`` is the `.Configuration` instance.
 
     .. note::
 

--- a/confidence.py
+++ b/confidence.py
@@ -3,6 +3,7 @@ from enum import IntEnum
 from functools import partial
 from itertools import chain, product
 from os import environ, path
+import re
 
 import yaml
 
@@ -321,8 +322,13 @@ def read_envvars(name, extension):
     if not values:
         return NotConfigured
 
-    # treat _'s as separators, FOO_NS_KEY=bar resulting in {'ns': {'key': 'bar'}}
-    return Configuration(values, separator='_')
+    def dotted(name):
+        # replace 'regular' underscores (those between alphanumeric characters) with dots first
+        name = re.sub(r'([0-9A-Za-z])_([0-9A-Za-z])', r'\1.\2', name)
+        # unescape double underscores back to a single one
+        return re.sub(r'__', '_', name)
+
+    return Configuration({dotted(name): value for name, value in values.items()})
 
 
 def read_envvar_file(name, extension):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -285,6 +285,7 @@ def test_load_name_envvars():
         'FOO_KEY': 'foo',
         'FOO_NS_KEY': 'value',
         'BAR_KEY': 'bar',
+        'BAR_N__S_KEY': 'space',
     }
 
     with patch('confidence.environ', env):
@@ -292,6 +293,7 @@ def test_load_name_envvars():
 
     assert subject.key == 'bar'
     assert subject.ns.key == 'value'
+    assert subject.n_s.key == 'space'
 
 
 def test_load_name_envvar_file():


### PR DESCRIPTION
Underscores in environment variables are interpreted as separators for the resulting attributes on the configuration object. This made it impossible to specify a configuration key resulting in a namespace that contains an underscore. This PR enables underscores in configuration namespaces through environment variables by differentiating between single and dual underscores. Environment variable `NAME_NAME__SPACE_KEY=foo` would show up on a `Configuration` instance as `config.name_space.key` when 'name' is loaded by `confidence.load_name`.

References #19.