### PR TITLE
Deny setting non-protected attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ development (master)
 
 - Enable escaping underscores in environment variables (``NAME_FOO__BAR`` results in ``config.foo_bar``)
 - Use ``yaml.safe_load`` to avoid security issues with ``yaml.load``
+- Raise ``AttributeError`` when attempting to set a non-protected attribute on a `Configuration` instance
 
 0.3 (2018-05-24)
 ----------------

--- a/confidence.py
+++ b/confidence.py
@@ -174,6 +174,14 @@ class Configuration(Mapping):
         return self.get(attr, default=NotConfigured)
 
     def __setattr__(self, name, value):
+        """
+        Attempts to set a named attribute to this `.Configuration` instance.
+        Only protected / private style attribute names are accepted, anything
+        not starting with an underscore will raise an `AttributeError`.
+
+        :param name: name of the attribute to set
+        :param value: value to be associated to *name*
+        """
         if name.startswith('_'):
             super().__setattr__(name, value)
         else:

--- a/confidence.py
+++ b/confidence.py
@@ -173,6 +173,12 @@ class Configuration(Mapping):
         """
         return self.get(attr, default=NotConfigured)
 
+    def __setattr__(self, name, value):
+        if name.startswith('_'):
+            super().__setattr__(name, value)
+        else:
+            raise AttributeError('assignment not supported ({})'.format(name))
+
     def __len__(self):
         return len(self._source)
 

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -1,5 +1,7 @@
 from collections import Mapping
 
+import pytest
+
 from confidence import Configuration, NotConfigured
 
 
@@ -51,3 +53,37 @@ def test_dir():
     assert 'key1' in dir(subject)
     assert 'namespace' in dir(subject)
     assert 'key3' in dir(subject.namespace)
+
+
+def test_assignments():
+    subject = Configuration({'key1': 'value', 'key2': 5, 'namespace.key3': False})
+
+    subject._private = 42
+    subject.__very_private = 43
+
+    assert subject._private == 42
+    assert subject.__very_private == 43
+
+    with pytest.raises(AttributeError) as e:
+        subject.non_existent = True
+    assert 'assignment not supported' in str(e.value) and 'non_existent' in str(e.value)
+
+    with pytest.raises(AttributeError) as e:
+        subject.key1 = True
+    assert 'assignment not supported' in str(e.value) and 'key1' in str(e.value)
+
+    with pytest.raises(AttributeError) as e:
+        subject.namespace.key3 = True
+    assert 'assignment not supported' in str(e.value) and 'key3' in str(e.value)
+
+    with pytest.raises(AttributeError) as e:
+        subject.namespace.key4 = True
+    assert 'assignment not supported' in str(e.value) and 'key4' in str(e.value)
+
+    with pytest.raises(AttributeError) as e:
+        subject.non_existent.key6 = True
+    assert 'assignment not supported' in str(e.value) and 'key6' in str(e.value)
+
+    with pytest.raises(AttributeError) as e:
+        subject.we.must.go.deeper = True
+    assert 'assignment not supported' in str(e.value) and 'deeper' in str(e.value)


### PR DESCRIPTION
Setting attributes has unforeseen side effects, particularly on `NotConfigured`. 

> Errors should never pass silently.
> — Tim Peters

References #26 