### PR TITLE
Raise a warning when a colliding or ambiguous key is specified

### DIFF
--- a/confidence.py
+++ b/confidence.py
@@ -4,6 +4,7 @@ from functools import partial
 from itertools import chain, product
 from os import environ, path
 import re
+import warnings
 
 import yaml
 
@@ -80,6 +81,37 @@ def _split_keys(mapping, separator='.'):
             key, rest = key.split(separator, 1)
             # use rest as the new key of value, recursively split that and update value
             value = _split_keys({rest: value}, separator)
+
+        if key in {'__abstractmethods__', '__class__', '__contains__',
+                   '__delattr__', '__dict__', '__dir__', '__doc__',
+                   '__eq__', '__format__', '__ge__', '__getattr__',
+                   '__getattribute__', '__getitem__', '__gt__', '__hash__',
+                   '__init__', '__init_subclass__', '__iter__', '__le__',
+                   '__len__', '__lt__', '__module__', '__ne__', '__new__',
+                   '__reduce__', '__reduce_ex__', '__repr__', '__reversed__',
+                   '__setattr__', '__sizeof__', '__slots__', '__str__',
+                   '__subclasshook__', '__weakref__', '_abc_cache',
+                   '_abc_negative_cache', '_abc_negative_cache_version',
+                   '_abc_registry', '_separator', '_source', 'get',
+                   'items', 'keys', 'values'}:
+            warnings.warn('The supplied configuration contains the key '
+                          '\'{reserved_key}\', which conflicts with '
+                          'methods used by mappings in Python. '
+                          'Accessing this attribute is not possible '
+                          'with the dot-separated notation, but only '
+                          'with the configuration\'s .get() '
+                          'method.'.format(reserved_key=key),
+                          UserWarning)
+
+        if key in {'clear', '__delitem__', 'setdefault', 'fromkeys',
+                   'popitem', 'copy', '__setitem__', 'pop', 'update'}:
+            warnings.warn('The supplied configuration contains the key '
+                          '\'{reserved_key\', which could cause confusion, '
+                          'as it is also used as a method on mappings in '
+                          'Python. Accessing this attribute is possible '
+                          'with the dot-separated notation, '
+                          'however.'.format(reserved_key=key),
+                          UserWarning)
 
         # merge the result so far with the (possibly updated / fixed / split) current key and value
         _merge(result, {key: value})


### PR DESCRIPTION
As discussed in #28, we might want to warn the user for keys that are in collision with members of an instance of ``Configuration`` or could cause other kinds of confusion. This warning mentions the consequence that these keys are no longer accessible with the dot-separated notation.