### PR TITLE
Warn about attribute collisions during merge and split of sources

### DIFF
--- a/confidence.py
+++ b/confidence.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Mapping
 from enum import IntEnum
 from functools import partial
@@ -80,6 +81,27 @@ def _split_keys(mapping, separator='.'):
             key, rest = key.split(separator, 1)
             # use rest as the new key of value, recursively split that and update value
             value = _split_keys({rest: value}, separator)
+
+        if key in {'__abstractmethods__', '__class__', '__contains__',
+                   '__delattr__', '__dict__', '__dir__', '__doc__',
+                   '__eq__', '__format__', '__ge__', '__getattr__',
+                   '__getattribute__', '__getitem__', '__gt__', '__hash__',
+                   '__init__', '__init_subclass__', '__iter__', '__le__',
+                   '__len__', '__lt__', '__module__', '__ne__', '__new__',
+                   '__reduce__', '__reduce_ex__', '__repr__', '__reversed__',
+                   '__setattr__', '__sizeof__', '__slots__', '__str__',
+                   '__subclasshook__', '__weakref__', '_abc_cache',
+                   '_abc_negative_cache', '_abc_negative_cache_version',
+                   '_abc_registry', '_separator', '_source', 'get',
+                   'items', 'keys', 'values'}:
+            warnings.warn('The supplied configuration contains the key '
+                          '\'{reserved_key}\', which conflicts with '
+                          'methods used by mappings in Python. '
+                          'Accessing this attribute is not possible '
+                          'with the dot-separated notation, but only '
+                          'with the configuration\'s .get() '
+                          'method.'.format(reserved_key=key),
+                          UserWarning)
 
         # merge the result so far with the (possibly updated / fixed / split) current key and value
         _merge(result, {key: value})

--- a/confidence.py
+++ b/confidence.py
@@ -83,13 +83,9 @@ def _split_keys(mapping, separator='.'):
             value = _split_keys({rest: value}, separator)
 
         if key in _COLLIDING_KEYS:
-            warnings.warn('The supplied configuration contains the key '
-                          '\'{reserved_key}\', which conflicts with '
-                          'methods used by mappings in Python. '
-                          'Accessing this attribute is not possible '
-                          'with the dot-separated notation, but only '
-                          'with the configuration\'s .get() '
-                          'method.'.format(reserved_key=key),
+            # warn about configured keys colliding with Configuration members
+            warnings.warn('key {key} collides with member of Configuration type, use get() method to retrieve key '
+                          '{key}'.format(key=key),
                           UserWarning)
 
         # merge the result so far with the (possibly updated / fixed / split) current key and value

--- a/confidence.py
+++ b/confidence.py
@@ -84,8 +84,8 @@ def _split_keys(mapping, separator='.'):
 
         if key in _COLLIDING_KEYS:
             # warn about configured keys colliding with Configuration members
-            warnings.warn('key {key} collides with member of Configuration type, use get() method to retrieve key '
-                          '{key}'.format(key=key),
+            warnings.warn('key {key} collides with member of Configuration type, use get() method to retrieve the '
+                          'value for {key}'.format(key=key),
                           UserWarning)
 
         # merge the result so far with the (possibly updated / fixed / split) current key and value

--- a/confidence.py
+++ b/confidence.py
@@ -82,18 +82,7 @@ def _split_keys(mapping, separator='.'):
             # use rest as the new key of value, recursively split that and update value
             value = _split_keys({rest: value}, separator)
 
-        if key in {'__abstractmethods__', '__class__', '__contains__',
-                   '__delattr__', '__dict__', '__dir__', '__doc__',
-                   '__eq__', '__format__', '__ge__', '__getattr__',
-                   '__getattribute__', '__getitem__', '__gt__', '__hash__',
-                   '__init__', '__init_subclass__', '__iter__', '__le__',
-                   '__len__', '__lt__', '__module__', '__ne__', '__new__',
-                   '__reduce__', '__reduce_ex__', '__repr__', '__reversed__',
-                   '__setattr__', '__sizeof__', '__slots__', '__str__',
-                   '__subclasshook__', '__weakref__', '_abc_cache',
-                   '_abc_negative_cache', '_abc_negative_cache_version',
-                   '_abc_registry', '_separator', '_source', 'get',
-                   'items', 'keys', 'values'}:
+        if key in _COLLIDING_KEYS:
             warnings.warn('The supplied configuration contains the key '
                           '\'{reserved_key}\', which conflicts with '
                           'methods used by mappings in Python. '
@@ -220,6 +209,9 @@ class Configuration(Mapping):
 
     def __dir__(self):
         return sorted(set(chain(super().__dir__(), self.keys())))
+
+
+_COLLIDING_KEYS = frozenset(dir(Configuration()))
 
 
 class NotConfigured(Configuration):

--- a/confidence.py
+++ b/confidence.py
@@ -1,10 +1,10 @@
-import warnings
 from collections.abc import Mapping
 from enum import IntEnum
 from functools import partial
 from itertools import chain, product
 from os import environ, path
 import re
+import warnings
 
 import yaml
 

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -1,4 +1,5 @@
-from collections import Mapping
+from collections.abc import Mapping
+from unittest.mock import patch
 
 import pytest
 
@@ -44,6 +45,20 @@ def test_not_configured():
     assert (subject.does_not_exist or 'default') == 'default'
     assert 'not configured' in str(subject.does_nope.exist)
     assert str(subject.does_nope_exist) == repr(subject.does.nope.exist)
+
+
+def test_collisions():
+    with patch('confidence.warnings') as warnings:
+        subject = Configuration({'key': 'value', 'keys': [1, 2], '_separator': '_'})
+
+    for collision in ('keys', '_separator'):
+        warnings.warn.assert_any_call('key {key} collides with member of Configuration type, use get() method to '
+                                      'retrieve key {key}'.format(key=collision),
+                                      UserWarning)
+
+    assert subject.key == 'value'
+    assert callable(subject.keys)
+    assert subject._separator == '.'
 
 
 def test_dir():

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -53,7 +53,7 @@ def test_collisions():
 
     for collision in ('keys', '_separator'):
         warnings.warn.assert_any_call('key {key} collides with member of Configuration type, use get() method to '
-                                      'retrieve key {key}'.format(key=collision),
+                                      'retrieve the value for {key}'.format(key=collision),
                                       UserWarning)
 
     assert subject.key == 'value'


### PR DESCRIPTION
Goes toward #28, using `warnings.warn` to alert users that particular configuration keys won't be accessible as attributes (`.get` will continue to work).