### PR TITLE
Reference configured keys from values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 development (master)
 --------------------
 
-
+- Enable referencing keys from values
 
 0.4.1 (2018-11-26)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,8 @@ Given the following YAML file:
 
     foo.baz: '21 is only half the answer'
 
+    foobar: the answer is ${foo.bar}…
+
 Use it with confidence:
 
 .. code:: python
@@ -36,6 +38,9 @@ Use it with confidence:
         value = 42
     # or, similar
     value = configuration.foo.whoopsie or 42
+
+    # even references to other configured values will work
+    value = configuration.foobar  # 'the answer is 42…'
 
 Often, combining multiple sources of configuration can be useful when
 defining defaults or reading from multiple files:

--- a/confidence.py
+++ b/confidence.py
@@ -121,6 +121,7 @@ class Configuration(Mapping):
             between keys
         """
         self._separator = separator
+        self._root = self
 
         self._source = {}
         for source in sources:
@@ -158,6 +159,7 @@ class Configuration(Mapping):
             elif isinstance(value, Mapping):
                 namespace = Configuration()
                 namespace._source = value
+                namespace._root = self._root
                 return namespace
             else:
                 return value

--- a/confidence.py
+++ b/confidence.py
@@ -171,6 +171,8 @@ class Configuration(Mapping):
                 namespace._source = value
                 namespace._root = self._root
                 return namespace
+            elif isinstance(value, str):
+                return self._resolve(value)
             else:
                 return value
         except KeyError:

--- a/confidence.py
+++ b/confidence.py
@@ -159,6 +159,15 @@ class Configuration(Mapping):
 
                 reference = self._root.get(path, resolve_references=False)
 
+                if isinstance(reference, Configuration):
+                    if match.span(0) != (0, len(value)):
+                        raise ConfiguredReferenceError(
+                            'cannot insert namespace at {path} into referring value'.format(path=path),
+                            key=path
+                        )
+
+                    return reference
+
                 value = '{start}{reference}{end}'.format(
                     start=value[:match.start(0)],
                     reference=reference,

--- a/confidence.py
+++ b/confidence.py
@@ -111,6 +111,8 @@ class Configuration(Mapping):
     or attributes.
     """
 
+    _template_pattern = re.compile(r'\${(?P<path>[^}]+?)}')
+
     def __init__(self, *sources, separator='.'):
         """
         Create a new `.Configuration`, based on one or multiple source mappings.
@@ -128,6 +130,14 @@ class Configuration(Mapping):
             if source:
                 # merge values from source into self._source, overwriting any corresponding keys
                 _merge(self._source, _split_keys(source, separator=self._separator), conflict=_Conflict.overwrite)
+
+    def _resolve(self, value):
+        match = self._template_pattern.search(value)
+        while match:
+            value = value[:match.start(0)] + self._root.get(match.group('path')) + value[match.end(0):]
+            match = self._template_pattern.search(value)
+
+        return value
 
     def get(self, path, default=_NoDefault, as_type=None):
         """

--- a/confidence.py
+++ b/confidence.py
@@ -159,26 +159,28 @@ class Configuration(Mapping):
 
                 reference = self._root.get(path, resolve_references=False)
 
-                if isinstance(reference, Configuration):
-                    if match.span(0) != (0, len(value)):
+                if match.span(0) != (0, len(value)):
+                    if isinstance(reference, Configuration):
                         raise ConfiguredReferenceError(
                             'cannot insert namespace at {path} into referring value'.format(path=path),
                             key=path
                         )
 
-                    return reference
-
-                value = '{start}{reference}{end}'.format(
-                    start=value[:match.start(0)],
-                    reference=reference,
-                    end=value[match.end(0):]
-                )
+                    value = '{start}{reference}{end}'.format(
+                        start=value[:match.start(0)],
+                        reference=reference,
+                        end=value[match.end(0):]
+                    )
+                else:
+                    value = reference
 
                 references.add(path)
 
-                match = self._reference_pattern.search(value)
+                if isinstance(value, str):
+                    match = self._reference_pattern.search(value)
+                else:
+                    match = None
 
-            # TODO: auto-convert value type to mimic value getting parsed from file?
             return value
         except NotConfiguredError as e:
             # TODO: error should include key that includes the missing reference

--- a/confidence.py
+++ b/confidence.py
@@ -159,7 +159,7 @@ class Configuration(Mapping):
 
             # TODO: auto-convert value type to mimic value getting parsed from file?
             return value
-        except ConfigurationError as e:
+        except NotConfiguredError as e:
             # TODO: error should include key that includes the missing reference
             raise ConfiguredReferenceError(
                 'unable to resolve referenced key {reference}'.format(reference=match.group('path')),
@@ -208,7 +208,8 @@ class Configuration(Mapping):
             if default is not _NoDefault:
                 return default
             else:
-                raise ConfigurationError('no configuration for key {}'.format(self._separator.join(steps_taken)))
+                missing_key = self._separator.join(steps_taken)
+                raise NotConfiguredError('no configuration for key {}'.format(missing_key), key=missing_key)
 
     def __getattr__(self, attr):
         """

--- a/confidence.py
+++ b/confidence.py
@@ -125,7 +125,7 @@ class Configuration(Mapping):
     or attributes.
     """
 
-    _template_pattern = re.compile(r'\${(?P<path>[^}]+?)}')
+    _reference_pattern = re.compile(r'\${(?P<path>[^}]+?)}')
 
     def __init__(self, *sources, separator='.'):
         """
@@ -146,7 +146,7 @@ class Configuration(Mapping):
                 _merge(self._source, _split_keys(source, separator=self._separator), conflict=_Conflict.overwrite)
 
     def _resolve(self, value):
-        match = self._template_pattern.search(value)
+        match = self._reference_pattern.search(value)
         references = set()
         try:
             while match:
@@ -176,7 +176,7 @@ class Configuration(Mapping):
 
                 references.add(path)
 
-                match = self._template_pattern.search(value)
+                match = self._reference_pattern.search(value)
 
             # TODO: auto-convert value type to mimic value getting parsed from file?
             return value

--- a/confidence.py
+++ b/confidence.py
@@ -166,7 +166,7 @@ class Configuration(Mapping):
                 key=e.key
             ) from e
 
-    def get(self, path, default=_NoDefault, as_type=None):
+    def get(self, path, default=_NoDefault, as_type=None, resolve_references=True):
         """
         Gets a value for the specified path.
 
@@ -198,7 +198,7 @@ class Configuration(Mapping):
                 namespace._source = value
                 namespace._root = self._root
                 return namespace
-            elif isinstance(value, str):
+            elif resolve_references and isinstance(value, str):
                 return self._resolve(value)
             else:
                 return value

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,0 +1,115 @@
+import pytest
+
+from confidence import Configuration, ConfigurationError, MissingReferenceError
+
+
+def test_value_types():
+    config = Configuration({
+        'ns.str': 'string',
+        'ns.int': 42,
+        'ns.float': 2.0,
+        'ns.bool': True,
+        'ns.ref1': 'prefix ${ns.str} suffix',
+        'ns.ref2': 'p${ns.int}s',
+        'ns.ref3': '${ns.float}',
+        'ns.ref4': '${ns.bool}',
+    })
+
+    assert config.ns.str == 'string'
+    assert config.ns.ref1 == config.get('ns.ref1') == 'prefix string suffix'
+    assert config.ns.ref2 == config.get('ns.ref2') == 'p42s'
+    assert config.ns.ref3 == config.get('ns.ref3') == 2.0
+    assert config.ns.ref4 == config.get('ns.ref4') is True
+
+
+def test_multiple_references():
+    config = Configuration({
+        'key': 'A seemingly ${ns.word1}, ${ns.word2} sentence.',
+        'ns.word1': 'full',
+        'ns.word2': 'complete',
+    })
+
+    assert config.key == 'A seemingly full, complete sentence.'
+
+
+def test_multi_level_reference():
+    config = Configuration({
+        'key': 'A ${ns.part1}',
+        'ns.part1': 'seemingly full, ${ns.part2}.',
+        'ns.part2': 'complete sentence',
+    })
+
+    assert config.ns.part2 == 'complete sentence'
+    assert config.ns.part1 == 'seemingly full, complete sentence.'
+    assert config.key == 'A seemingly full, complete sentence.'
+
+
+def test_sub_config_reference():
+    config = Configuration({
+        'key': 'string',
+        'ns.test1': '${key}',
+        'ns.test2': '${ns.test1}',
+    })
+
+    assert config.key == 'string'
+
+    ns = config.ns
+    assert ns.test1 == ns.get('test1') == 'string'
+    assert ns.test2 == ns.get('test2') == 'string'
+
+    ns = config.get('ns')
+    assert ns.test1 == ns.get('test1') == 'string'
+    assert ns.test2 == ns.get('test2') == 'string'
+
+
+def test_reference_ns():
+    config = Configuration({
+        'key': '${ns}',
+        'ns.key': 'string',
+    })
+
+    assert config.ns.key == 'string'
+    assert isinstance(config.key, Configuration)
+    assert config.key.key == 'string'
+
+
+def test_missing_reference():
+    config = Configuration({
+        'key': 'string',
+        'template.working': '${key}',
+        'template.missing': '${ns.key}',
+    })
+
+    assert config.key == 'string'
+    assert config.template.working == 'string'
+
+    with pytest.raises(MissingReferenceError) as e:
+        assert not config.template.missing
+    assert 'ns.key' in str(e.value)
+
+    with pytest.raises(MissingReferenceError) as e:
+        assert not config.get('template.missing')
+    assert 'ns.key' in str(e.value)
+
+
+def test_self_recursion():
+    config = Configuration({
+        'ns.key': '${ns.key}',
+    })
+
+    with pytest.raises(ConfigurationError) as e:
+        assert not config.ns.key
+
+    assert 'ns.key' in str(e.value) and 'recursive' in str(e.value)
+
+
+def test_loop_recursion():
+    config = Configuration({
+        'ns.key': '${ns.ns.key}',
+        'ns.ns.key': '${ns.key}',
+    })
+
+    with pytest.raises(ConfigurationError) as e:
+        assert not config.ns.key
+
+    assert 'ns.key' in str(e.value) and 'recursive' in str(e.value)

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,6 +1,6 @@
 import pytest
 
-from confidence import Configuration, ConfigurationError, MissingReferenceError
+from confidence import Configuration, ConfigurationError, ConfiguredReferenceError
 
 
 def test_value_types():
@@ -83,11 +83,11 @@ def test_missing_reference():
     assert config.key == 'string'
     assert config.template.working == 'string'
 
-    with pytest.raises(MissingReferenceError) as e:
+    with pytest.raises(ConfiguredReferenceError) as e:
         assert not config.template.missing
     assert 'ns.key' in str(e.value)
 
-    with pytest.raises(MissingReferenceError) as e:
+    with pytest.raises(ConfiguredReferenceError) as e:
         assert not config.get('template.missing')
     assert 'ns.key' in str(e.value)
 

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -66,11 +66,16 @@ def test_reference_ns():
     config = Configuration({
         'key': '${ns}',
         'ns.key': 'string',
+        'broken': 'no ${ns} inside',
     })
 
     assert config.ns.key == 'string'
     assert isinstance(config.key, Configuration)
     assert config.key.key == 'string'
+
+    with pytest.raises(ConfiguredReferenceError) as e:
+        assert not config.broken
+    assert 'cannot insert namespace' in str(e.value)
 
 
 def test_missing_reference():


### PR DESCRIPTION
As expressed in #29: enable references in values to refer or 'fill' values from other keys. Proposed syntax:

~~~~ yaml
namespace:
  key: value
another.namespace:
  key: a value containing another ${namespace.key}
~~~~

Referencing a full namespace works as long as it's not referenced as a template (e.g.: `key: ${namespace}`, not as in the example above).

Question 1: using the 'often used' `${}`-style syntax sort of clashes with Python's own `{}`-style string formatting. While references shouldn't make it into runtime code (they're resolved by default, crashing when not found (see also question 2)), will this prove to be annoying / problematic in syntax highlighting or at runtime?

Question 2: how do we deal with references that are not configured? When 'filling a template', raising an error seems like a logical choice, but referring to a full namespace that happens to be `NotConfigured` could be treated 'normally', just returning `NotConfigured`... Currently: both these cases will raise a `ConfiguredReferenceError`.

