### PR TITLE
Enable easy override of default load order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ development (master)
 --------------------
 
 - Enable referencing keys from values
+- Enable customizing load order for `load_name` through `loaders` and `Locality` (default behaviour remains unchanged)
 
 0.4.1 (2018-11-26)
 ------------------
@@ -21,7 +22,7 @@ development (master)
 0.3 (2018-05-24)
 ----------------
 
-- Enable ignoring missing files in ``loadf``.
+- Enable ignoring missing files in `loadf`.
 - Fix crashes when reading empty or comment-only yaml files.
 
 0.2 (2018-03-06)
@@ -34,7 +35,7 @@ development (master)
 0.1.1 (2018-01-12)
 ------------------
 
-- Expand user dirs for arguments to ``loadf``, including values for ``EXAMPLE_CONFIG_FILE`` environment variables.
+- Expand user dirs for arguments to `loadf`, including values for ``EXAMPLE_CONFIG_FILE`` environment variables.
 
 0.1 (2017-12-18)
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,13 @@ defining defaults or reading from multiple files:
     # if set, load_name will take a look at environment variables like
     # APP_FOO_BAR and APP_FOO_BAZ, mixing those in as foo.bar and foo.baz
 
+    # the default load order can be overridden if necessary:
+
+    configuration = confidence.load_name('app', load_order=confidence.loaders(
+        # loading system after user makes system locations take precedence
+        confidence.Locality.user, confidence.Locality.system
+    ))
+
 While powerful, no set of convenience functions will ever satisfy
 everyone's use case. To be able to serve as wide an audience as
 possible, confidence doesn't hide away its flexible internal API.

--- a/confidence.py
+++ b/confidence.py
@@ -484,6 +484,13 @@ def read_envvar_dir(envvar, name, extension):
     return loadf(config_path, default=NotConfigured)
 
 
+class Locality(IntEnum):
+    system = 0
+    user = 1
+    application = 2
+    environment = 3
+
+
 # ordered sequence of name templates to load, in increasing significance
 LOAD_ORDER = (
     # system-wide locations

--- a/confidence.py
+++ b/confidence.py
@@ -561,13 +561,13 @@ def loaders(*specifiers):
             yield specifier
 
 
-LOAD_ORDER = tuple(loaders(Locality.system,
-                           Locality.user,
-                           Locality.application,
-                           Locality.environment))
+DEFAULT_LOAD_ORDER = tuple(loaders(Locality.system,
+                                   Locality.user,
+                                   Locality.application,
+                                   Locality.environment))
 
 
-def load_name(*names, load_order=LOAD_ORDER, extension='yaml'):
+def load_name(*names, load_order=DEFAULT_LOAD_ORDER, extension='yaml'):
     """
     Read a `.Configuration` instance by name, trying to read from files in
     increasing significance. The default load order is `.system`, `.user`,

--- a/confidence.py
+++ b/confidence.py
@@ -491,6 +491,37 @@ class Locality(IntEnum):
     environment = 3
 
 
+_LOADERS = {
+    Locality.system: (
+        # system-wide locations
+        read_xdg_config_dirs,
+        '/etc/{name}.{extension}',
+        '/Library/Preferences/{name}.{extension}',
+        partial(read_envvar_dir, 'PROGRAMDATA'),
+    ),
+
+    Locality.user: (
+        # user-local locations
+        read_xdg_config_home,
+        '~/Library/Preferences/{name}.{extension}',
+        partial(read_envvar_dir, 'APPDATA'),
+        partial(read_envvar_dir, 'LOCALAPPDATA'),
+        '~/.{name}.{extension}',
+    ),
+
+    Locality.application: (
+        # application-local locations
+        './{name}.{extension}',
+    ),
+
+    Locality.environment: (
+        # application-specific environment variables
+        read_envvar_file,
+        read_envvars,
+    )
+}
+
+
 # ordered sequence of name templates to load, in increasing significance
 LOAD_ORDER = (
     # system-wide locations

--- a/confidence.py
+++ b/confidence.py
@@ -523,15 +523,17 @@ _LOADERS = {
 
 
 def loaders(*specifiers):
-    return tuple(chain.from_iterable(
-        _LOADERS[locality] for locality in specifiers
-    ))
+    for specifier in specifiers:
+        if isinstance(specifier, Locality):
+            yield from _LOADERS[specifier]
+        else:
+            yield specifier
 
 
-LOAD_ORDER = loaders(Locality.system,
-                     Locality.user,
-                     Locality.application,
-                     Locality.environment)
+LOAD_ORDER = tuple(loaders(Locality.system,
+                           Locality.user,
+                           Locality.application,
+                           Locality.environment))
 
 
 def load_name(*names, load_order=LOAD_ORDER, extension='yaml'):

--- a/confidence.py
+++ b/confidence.py
@@ -485,10 +485,16 @@ def read_envvar_dir(envvar, name, extension):
 
 
 class Locality(IntEnum):
-    system = 0
-    user = 1
-    application = 2
-    environment = 3
+    """
+    Enumeration of localities defined by confidence, ranging from system-wide
+    locations for configurations (e.g. ``/etc/name.yaml``) to environment
+    variables.
+    """
+
+    system = 0  #: system-wide configuration locations
+    user = 1  #: user-local configuration locations
+    application = 2  #: application-local configuration locations (dependent on the current working directory)
+    environment = 3  #: configuration from environment variables
 
 
 _LOADERS = {

--- a/confidence.py
+++ b/confidence.py
@@ -529,10 +529,35 @@ _LOADERS = {
 
 
 def loaders(*specifiers):
+    """
+    Generates loaders in the specified order.
+
+    Arguments can be `.Locality` instances, producing the loader(s) available
+    for that locality, `str` instances (used as file path templates) or
+    `callable`s. These can be mixed:
+
+    .. code-block:: python
+
+        # define a load order using predefined user-local locations,
+        # an explicit path, a template and a user-defined function
+        load_order = loaders(Locality.user,
+                             '/etc/defaults/hard-coded.yaml',
+                             '/path/to/{name}.{extension}',
+                             my_loader)
+
+        # load configuration for name 'my-application' using the load order
+        # defined above
+        config = load_name('my-application', load_order=load_order)
+
+    :param specifiers:
+    :return: a `generator` of configuration loaders in the specified order
+    """
     for specifier in specifiers:
         if isinstance(specifier, Locality):
+            # localities can carry multiple loaders, flatten this
             yield from _LOADERS[specifier]
         else:
+            # something not a locality, pass along verbatim
             yield specifier
 
 

--- a/confidence.py
+++ b/confidence.py
@@ -522,26 +522,16 @@ _LOADERS = {
 }
 
 
-# ordered sequence of name templates to load, in increasing significance
-LOAD_ORDER = (
-    # system-wide locations
-    read_xdg_config_dirs,
-    '/etc/{name}.{extension}',
-    '/Library/Preferences/{name}.{extension}',
-    partial(read_envvar_dir, 'PROGRAMDATA'),
+def loaders(*specifiers):
+    return tuple(chain.from_iterable(
+        _LOADERS[locality] for locality in specifiers
+    ))
 
-    # user-local locations
-    read_xdg_config_home,
-    '~/Library/Preferences/{name}.{extension}',
-    partial(read_envvar_dir, 'APPDATA'),
-    partial(read_envvar_dir, 'LOCALAPPDATA'),
-    '~/.{name}.{extension}',
 
-    # application-local locations
-    './{name}.{extension}',
-    read_envvar_file,
-    read_envvars,
-)
+LOAD_ORDER = loaders(Locality.system,
+                     Locality.user,
+                     Locality.application,
+                     Locality.environment)
 
 
 def load_name(*names, load_order=LOAD_ORDER, extension='yaml'):

--- a/confidence.py
+++ b/confidence.py
@@ -545,8 +545,12 @@ LOAD_ORDER = tuple(loaders(Locality.system,
 def load_name(*names, load_order=LOAD_ORDER, extension='yaml'):
     """
     Read a `.Configuration` instance by name, trying to read from files in
-    increasing significance. System-wide configuration locations are preceded
-    by user locations, and again by local files.
+    increasing significance. The default load order is `.system`, `.user`,
+    `.application`, `.environment`.
+
+    Multiple names are combined with multiple loaders using names as the 'inner
+    loop / selector', loading ``/etc/name1.yaml`` and ``/etc/name2.yaml``
+    before ``./name1.yaml`` and ``./name2.yaml``.
 
     :param names: application or configuration set names, in increasing
         significance

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3,7 +3,7 @@ from os import path
 import pytest
 from unittest.mock import call, patch
 
-from confidence import Configuration, LOAD_ORDER, load, load_name, loadf, loads, NotConfigured
+from confidence import Configuration, LOAD_ORDER, load, load_name, loaders, loadf, loads, Locality, NotConfigured
 from confidence import read_envvar_file, read_envvars, read_xdg_config_dirs, read_xdg_config_home
 
 
@@ -321,7 +321,7 @@ def test_load_name_overlapping_envvars():
     }
 
     with patch('confidence.environ', env):
-        subject = load_name('foo', 'bar', load_order=(read_envvar_file, read_envvars))
+        subject = load_name('foo', 'bar', load_order=loaders(Locality.environment))
 
     assert subject.key == 'bar'
     assert subject.ns.key == 'value'

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3,7 +3,7 @@ from os import path
 import pytest
 from unittest.mock import call, patch
 
-from confidence import Configuration, LOAD_ORDER, load, load_name, loaders, loadf, loads, Locality, NotConfigured
+from confidence import Configuration, DEFAULT_LOAD_ORDER, load, load_name, loaders, loadf, loads, Locality, NotConfigured
 from confidence import read_envvar_file, read_envvars, read_xdg_config_dirs, read_xdg_config_home
 
 
@@ -340,8 +340,8 @@ def test_load_name_envvar_dir():
         'APPDATA': 'D:/Users/user/AppData/Roaming'
     }
 
-    # only the envvar dir loaders are partials in LOAD_ORDER
-    load_order = [loader for loader in LOAD_ORDER if isinstance(loader, partial)]
+    # only the envvar dir loaders are partials in DEFAULT_LOAD_ORDER
+    load_order = [loader for loader in DEFAULT_LOAD_ORDER if isinstance(loader, partial)]
 
     with patch('confidence.path') as mocked_path, patch('confidence.loadf') as mocked_loadf, patch('confidence.environ', env):
         # hard-code user-expansion, unmock join

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,17 +1,17 @@
 from itertools import chain, groupby
 
-from confidence import _LOADERS, LOAD_ORDER, loaders, Locality
+from confidence import _LOADERS, DEFAULT_LOAD_ORDER, loaders, Locality
 
 
 def test_default_load_order_all_loaders():
     all_loaders = set(chain.from_iterable(_LOADERS.values()))
-    assert len(all_loaders) == len(LOAD_ORDER)
-    assert all(loader in LOAD_ORDER for loader in all_loaders)
+    assert len(all_loaders) == len(DEFAULT_LOAD_ORDER)
+    assert all(loader in DEFAULT_LOAD_ORDER for loader in all_loaders)
 
 
 def test_default_load_order_locality():
     localities = {loader: locality for locality, local_loaders in _LOADERS.items() for loader in local_loaders}
-    localities = map(localities.get, LOAD_ORDER)
+    localities = map(localities.get, DEFAULT_LOAD_ORDER)
 
     assert tuple(key for key, _ in groupby(localities)) == tuple(sorted(Locality))
 

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,35 @@
+from itertools import chain, groupby
+
+from confidence import _LOADERS, LOAD_ORDER, loaders, Locality
+
+
+def test_default_load_order_all_loaders():
+    all_loaders = set(chain.from_iterable(_LOADERS.values()))
+    assert len(all_loaders) == len(LOAD_ORDER)
+    assert all(loader in LOAD_ORDER for loader in all_loaders)
+
+
+def test_default_load_order_locality():
+    localities = {loader: locality for locality, local_loaders in _LOADERS.items() for loader in local_loaders}
+    localities = map(localities.get, LOAD_ORDER)
+
+    assert tuple(key for key, _ in groupby(localities)) == tuple(sorted(Locality))
+
+
+def test_no_loaders():
+    assert tuple(*loaders()) == ()
+
+
+def test_locality_loaders():
+    assert tuple(loaders(Locality.user)) == _LOADERS[Locality.user]
+    assert tuple(loaders(Locality.system, Locality.application)) == tuple(chain(_LOADERS[Locality.system], _LOADERS[Locality.application]))
+    assert tuple(loaders(Locality.environment, Locality.environment)) == tuple(chain(_LOADERS[Locality.environment], _LOADERS[Locality.environment]))
+
+
+def test_loaders_mixed():
+    def function():
+        pass
+
+    assert tuple(loaders('just a string')) == ('just a string',)
+    assert tuple(loaders('just a string', function)) == ('just a string', function)
+    assert tuple(loaders(function, Locality.environment, '{name}.{extension}')) == tuple(chain([function], _LOADERS[Locality.environment], ['{name}.{extension}']))


### PR DESCRIPTION
As in #32, introduces `Locality` enum grouping loader templates and callables and `loaders` to create a custom load order.