### PR TITLE
Enable raising error for unconfigured keys

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 development (master)
 --------------------
 
-
+- Add `Missing` policy to control what to do with unconfigured keys on attribute access
 
 0.5 (2019-02-01)
 ----------------

--- a/confidence.py
+++ b/confidence.py
@@ -333,7 +333,7 @@ def load(*fps):
     return Configuration(*(yaml.safe_load(fp.read()) for fp in fps))
 
 
-def loadf(*fnames, default=_NoDefault):
+def loadf(*fnames, default=_NoDefault, missing='safe'):
     """
     Read a `.Configuration` instance from named files.
 
@@ -352,10 +352,10 @@ def loadf(*fnames, default=_NoDefault):
         else:
             return default
 
-    return Configuration(*(readf(path.expanduser(fname)) for fname in fnames))
+    return Configuration(*(readf(path.expanduser(fname)) for fname in fnames), missing=missing)
 
 
-def loads(*strings):
+def loads(*strings, missing='safe'):
     """
     Read a `.Configuration` instance from strings.
 
@@ -363,7 +363,7 @@ def loads(*strings):
     :return: a `.Configuration` instance providing values from *strings*
     :rtype: `.Configuration`
     """
-    return Configuration(*(yaml.safe_load(string) for string in strings))
+    return Configuration(*(yaml.safe_load(string) for string in strings), missing=missing)
 
 
 def read_xdg_config_dirs(name, extension):
@@ -577,7 +577,7 @@ DEFAULT_LOAD_ORDER = tuple(loaders(Locality.system,
                                    Locality.environment))
 
 
-def load_name(*names, load_order=DEFAULT_LOAD_ORDER, extension='yaml'):
+def load_name(*names, load_order=DEFAULT_LOAD_ORDER, extension='yaml', missing='safe'):
     """
     Read a `.Configuration` instance by name, trying to read from files in
     increasing significance. The default load order is `.system`, `.user`,
@@ -592,6 +592,8 @@ def load_name(*names, load_order=DEFAULT_LOAD_ORDER, extension='yaml'):
     :param load_order: ordered list of name templates or `callable`s, in
         increasing order of significance
     :param extension: file extension to be used
+    :param missing: how to treat a missing / unconfigured key, either
+        ``'safe'`` or ``'raise'``
     :return: a `.Configuration` instances providing values loaded from *names*
         in *load_order* ordering
     """
@@ -606,4 +608,4 @@ def load_name(*names, load_order=DEFAULT_LOAD_ORDER, extension='yaml'):
                 candidate = path.expanduser(source.format(name=name, extension=extension))
                 yield loadf(candidate, default=NotConfigured)
 
-    return Configuration(*generate_sources())
+    return Configuration(*generate_sources(), missing=missing)

--- a/confidence.py
+++ b/confidence.py
@@ -157,9 +157,9 @@ class Configuration(Mapping):
         self._missing = missing
         self._root = self
 
-        if isinstance(self._missing, (Missing, str)):
+        if isinstance(self._missing, Missing):
             self._missing = {Missing.silent: NotConfigured,
-                             Missing.error: _NoDefault}[Missing(missing)]
+                             Missing.error: _NoDefault}[missing]
 
         self._source = {}
         for source in sources:

--- a/confidence.py
+++ b/confidence.py
@@ -300,9 +300,6 @@ class Configuration(Mapping):
         return sorted(set(chain(super().__dir__(), self.keys())))
 
 
-_COLLIDING_KEYS = frozenset(dir(Configuration()))
-
-
 class NotConfigured(Configuration):
     """
     Sentinel value to signal there is no value for a requested key.
@@ -318,6 +315,11 @@ class NotConfigured(Configuration):
 
 # overwrite NotConfigured as an instance of itself, a Configuration instance without any values
 NotConfigured = NotConfigured()
+# NB: NotConfigured._missing refers to the NotConfigured *class* at this point, fix this after the name override
+NotConfigured._missing = NotConfigured
+
+
+_COLLIDING_KEYS = frozenset(dir(Configuration()))
 
 
 def load(*fps):

--- a/confidence.py
+++ b/confidence.py
@@ -237,7 +237,7 @@ class Configuration(Mapping):
             if as_type:
                 return as_type(value)
             elif isinstance(value, Mapping):
-                namespace = Configuration()
+                namespace = type(self)(separator=self._separator, missing=self._missing)
                 namespace._source = value
                 # carry the root object from namespace to namespace, references are always resolved from root
                 namespace._root = self._root
@@ -250,12 +250,12 @@ class Configuration(Mapping):
         except ConfiguredReferenceError:
             # also a KeyError, but this one should bubble to caller
             raise
-        except KeyError:
+        except KeyError as e:
             if default is not _NoDefault:
                 return default
             else:
                 missing_key = self._separator.join(steps_taken)
-                raise NotConfiguredError('no configuration for key {}'.format(missing_key), key=missing_key)
+                raise NotConfiguredError('no configuration for key {}'.format(missing_key), key=missing_key) from e
 
     def __getattr__(self, attr):
         """

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from confidence import Configuration, NotConfigured
+from confidence import Configuration, Missing, NotConfigured
 
 
 def test_empty():
@@ -34,7 +34,7 @@ def test_value_types():
 
 
 def test_not_configured():
-    subject = Configuration({'key': 'value'})
+    subject = Configuration({'key': 'value'}, missing=Missing.silent)
 
     assert subject.key == 'value'
     assert subject.does_nope_exist is NotConfigured
@@ -102,3 +102,22 @@ def test_assignments():
     with pytest.raises(AttributeError) as e:
         subject.we.must.go.deeper = True
     assert 'assignment not supported' in str(e.value) and 'deeper' in str(e.value)
+
+
+def test_missing_error():
+    subject = Configuration({'key1': 'value', 'key2': 5, 'namespace.key3': False}, missing=Missing.error)
+
+    assert subject.key1 == 'value'
+
+    with pytest.raises(AttributeError) as e:
+        assert subject.namespace.key3 is False
+        assert not subject.key3
+
+    assert 'key3' in str(e.value)
+
+
+def test_missing_default():
+    subject = Configuration({'key1': 'value', 'key2': 5, 'namespace.key3': False}, missing='just a default')
+
+    assert subject.namespace.key3 is False
+    assert subject.key3 == 'just a default'


### PR DESCRIPTION
Adds a `missing` parameter to all load functions and the `Configuration` constructor, accepting either a `Missing` sentinel value (defaulting to the current behaviour) or a default value to be returned when an unconfigured key is requested through attribute access.

References #36.