### PR TITLE
[To master] Fix the problem where string-splitting is attempted on integers

### DIFF
--- a/confidence.py
+++ b/confidence.py
@@ -100,7 +100,7 @@ def _split_keys(mapping, separator='.'):
             # recursively split key(s) in value
             value = _split_keys(value, separator)
 
-        if separator in key:
+        if isinstance(key, str) and separator in key:
             # update key to be the first part before the separator
             key, rest = key.split(separator, 1)
             # use rest as the new key of value, recursively split that and update value

--- a/confidence.py
+++ b/confidence.py
@@ -224,11 +224,13 @@ class Configuration(Mapping):
         value = self._source
         steps_taken = []
         try:
-            # walk through the values dictionary
-            for step in path.split(self._separator):
-                steps_taken.append(step)
-                value = value[step]
-
+            if isinstance(path, str):
+                # walk through the values dictionary
+                for step in path.split(self._separator):
+                    steps_taken.append(step)
+                    value = value[step]
+            elif isinstance(path, int):
+                return list(value.values())[0]
             if as_type:
                 return as_type(value)
             elif isinstance(value, Mapping):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -132,3 +132,25 @@ def test_split_overlap_complex():
             }
         }
     }
+
+
+def test_split_integer_keys():
+    subject = {
+        42: 'test',
+        43: {'does.it.split.afterwards': 'yes'},
+        'what': {
+            'about.when': {
+                42: {'is.in.the.middle': 'hopefully'}
+            }
+        }
+    }
+
+    separated = _split_keys(subject)
+
+    assert separated == {
+        42: 'test',
+        43: {'does': {'it': {'split': {'afterwards': 'yes'}}}},
+        'what': {'about': {'when': {42: {'is': {'in': {'the': {
+            'middle': 'hopefully'
+        }}}}}}}
+    }


### PR DESCRIPTION
Given a yaml where a key is an integer, ``confidence`` crashed on trying to find the separator in this key.

This pull request fixes that by checking if the key is a string first. 

It also includes a new test. It even passes!