### PR TITLE
Specify PyPy versions in Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ python:
   - 3.5
   - 3.6
   - 3.7
-  - pypy3.5
+  - pypy3.5-7.0
+  - pypy3.6-7.0
 
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
Attempts to fix the travis build and specify the versions of PyPy to be used.