### PR TITLE
Dealing with non-str keys

### DIFF
--- a/confidence/utils.py
+++ b/confidence/utils.py
@@ -53,7 +53,7 @@ def _split_keys(mapping, separator='.', colliding=None):
 
     .. note::
 
-        All keys are coerced to `str` for use within a `.Configuration` object.
+        Keys not of type `str` are not supported and will raise errors.
 
     :param mapping: the mapping to process
     :param separator: the character (sequence) to use as the separator between

--- a/confidence/utils.py
+++ b/confidence/utils.py
@@ -68,8 +68,10 @@ def _split_keys(mapping, separator='.', colliding=None):
             # recursively split key(s) in value
             value = _split_keys(value, separator)
 
-        # make sure the key being used is interpreted as a str to avoid issues later
-        key = str(key)
+        # reject non-str keys, avoid complicating access patterns
+        if not isinstance(key, str):
+            raise ValueError('non-str type keys ({0}, {0.__class__.__module__}.{0.__class__.__name__}) '
+                             'not supported'.format(key))
 
         if separator in key:
             # update key to be the first part before the separator

--- a/confidence/utils.py
+++ b/confidence/utils.py
@@ -51,6 +51,10 @@ def _split_keys(mapping, separator='.', colliding=None):
     Recursively walks *mapping* to split keys that contain the separator into
     nested mappings.
 
+    .. note::
+
+        All keys are coerced to `str` for use within a `.Configuration` object.
+
     :param mapping: the mapping to process
     :param separator: the character (sequence) to use as the separator between
         keys

--- a/confidence/utils.py
+++ b/confidence/utils.py
@@ -64,6 +64,9 @@ def _split_keys(mapping, separator='.', colliding=None):
             # recursively split key(s) in value
             value = _split_keys(value, separator)
 
+        # make sure the key being used is interpreted as a str to avoid issues later
+        key = str(key)
+
         if separator in key:
             # update key to be the first part before the separator
             key, rest = key.split(separator, 1)

--- a/tests/files/complicated.yaml
+++ b/tests/files/complicated.yaml
@@ -1,6 +1,6 @@
 a.complicated:
   example: example
-  2019:
+  '2019':
     a: 'a'
   2019.b: 'b'
 
@@ -8,4 +8,4 @@ a:
   simple:
     reference: ${a.complicated}
   complicated.reference: value with ${a.complicated.2019.a} reference in it
-  2019-03-28: 2019-03-28
+  '2019-03-28': 2019-03-28

--- a/tests/files/complicated.yaml
+++ b/tests/files/complicated.yaml
@@ -1,0 +1,11 @@
+a.complicated:
+  example: example
+  2019:
+    a: 'a'
+  2019.b: 'b'
+
+a:
+  simple:
+    reference: ${a.complicated}
+  complicated.reference: value with ${a.complicated.2019.a} reference in it
+  2019-03-28: 2019-03-28

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,9 +1,13 @@
 from collections.abc import Mapping, Sequence
+from os import path
 
 import pytest
 
-from confidence import Configuration, ConfigurationError
+from confidence import Configuration, ConfigurationError, loadf
 from confidence.models import _NoDefault
+
+
+test_files = path.join(path.dirname(__file__), 'files')
 
 
 def test_empty():
@@ -50,3 +54,11 @@ def test_as_type():
 
 def test_no_default_doc_friendly():
     assert 'raise' in repr(_NoDefault)
+
+
+def test_key_types_from_file():
+    config = loadf(path.join(test_files, 'complicated.yaml'))
+
+    assert isinstance(config.get('a.complicated.2019'), Configuration)
+    assert config.get('a.complicated.2019.a') == 'a'
+    assert config.get('a.complicated.2019.b') == 'b'

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,6 +1,11 @@
+from os import path
+
 import pytest
 
-from confidence import Configuration, ConfigurationError, ConfiguredReferenceError, NotConfigured
+from confidence import Configuration, ConfigurationError, ConfiguredReferenceError, loadf, NotConfigured
+
+
+test_files = path.join(path.dirname(__file__), 'files')
 
 
 def test_reference_syntax():
@@ -145,3 +150,12 @@ def test_loop_recursion():
         assert not config.ns.key
 
     assert 'ns.key' in str(e.value) and 'recursive' in str(e.value)
+
+
+def test_references_from_file():
+    config = loadf(path.join(test_files, 'complicated.yaml'))
+
+    assert isinstance(config.a.simple.reference, Configuration)
+    assert config.a.simple.reference.example == 'example'
+
+    assert config.a.complicated.reference == 'value with a reference in it'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import pytest
+
 from confidence.utils import _Conflict, _merge, _split_keys
 
 
@@ -70,18 +72,6 @@ def test_merge_conflict_overwrite():
     assert merged['parent']['first'] == 4
 
 
-def test_merge_key_types():
-    left = {'parent': {1234: {1: 1}}}
-    right = {'parent': {'1234': {'2': 2}}}
-
-    merged = _merge(left, right)
-
-    assert len(merged['parent']) == 1
-    assert merged['parent']['1234'] == {'1': 1, '2': 2}
-
-    assert merged == _merge(right, left)
-
-
 def test_split_none():
     subject = {'key': 'value', 'another_key': 123}
 
@@ -150,19 +140,11 @@ def test_split_key_types():
     subject = {
         'ns.1234.key': 42,
         'ns': {
-            1234: {'key2': 43},
-            True: False
+            1234: {'key2': 43}
         }
     }
 
-    separated = _split_keys(subject)
+    with pytest.raises(ValueError) as e:
+        assert not _split_keys(subject)
 
-    assert separated == {
-        'ns': {
-            '1234': {
-                'key': 42,
-                'key2': 43
-            },
-            'True': False
-        }
-    }
+    assert '1234' in str(e.value)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -132,3 +132,25 @@ def test_split_overlap_complex():
             }
         }
     }
+
+
+def test_split_key_types():
+    subject = {
+        'ns.1234.key': 42,
+        'ns': {
+            1234: {'key2': 43},
+            True: False
+        }
+    }
+
+    separated = _split_keys(subject)
+
+    assert separated == {
+        'ns': {
+            '1234': {
+                'key': 42,
+                'key2': 43
+            },
+            'True': False
+        }
+    }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -70,6 +70,18 @@ def test_merge_conflict_overwrite():
     assert merged['parent']['first'] == 4
 
 
+def test_merge_key_types():
+    left = {'parent': {1234: {1: 1}}}
+    right = {'parent': {'1234': {'2': 2}}}
+
+    merged = _merge(left, right)
+
+    assert len(merged['parent']) == 1
+    assert merged['parent']['1234'] == {'1': 1, '2': 2}
+
+    assert merged == _merge(right, left)
+
+
 def test_split_none():
     subject = {'key': 'value', 'another_key': 123}
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import pytest
 
 from confidence.utils import _Conflict, _merge, _split_keys
@@ -148,3 +150,17 @@ def test_split_key_types():
         assert not _split_keys(subject)
 
     assert '1234' in str(e.value)
+    assert 'int' in str(e.value)
+
+    subject = {
+        'ns.2019-04-01.key': 42,
+        'ns': {
+            date(2019, 4, 1): {'key2': 43}
+        }
+    }
+
+    with pytest.raises(ValueError) as e:
+        assert not _split_keys(subject)
+
+    assert '2019-04-01' in str(e.value)
+    assert 'datetime.date' in str(e.value)


### PR DESCRIPTION
Implementation by @bartbroere allows non-`str` keys, alternative 'fix' is to always coerce keys to `str`. One of the added tests is known to fail, we could view `_merge` as internal API and keep this function oblivious of the problem, knowing that all the `load*`-functions and the `Configuration` constructor will always call `_split_keys` which always calls the fix.

References #41, #43.