### PR TITLE
Fix bug when Configuration source is a Configuration instance containing a reference

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 development (master)
 --------------------
 
-
+- Fix resolving references during loading when sources passed to `Configuration` are `Configuration` instances themselves.
 
 0.6 (2019-04-05)
 ----------------

--- a/confidence/models.py
+++ b/confidence/models.py
@@ -53,6 +53,10 @@ class Configuration(Mapping):
         self._source = {}
         for source in sources:
             if source:
+                while isinstance(source, Configuration):
+                    # _merge will walk source.items(), using source.get(), avoid resolving references now
+                    source = source._source
+
                 # merge values from source into self._source, overwriting any corresponding keys
                 _merge(self._source,
                        _split_keys(source, separator=self._separator, colliding=_COLLIDING_KEYS),

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -159,3 +159,12 @@ def test_references_from_file():
     assert config.a.simple.reference.example == 'example'
 
     assert config.a.complicated.reference == 'value with a reference in it'
+
+
+def test_missing_reference_during_merge():
+    source1 = Configuration({'ns.key2': '${ns.key}'})  # reference should only be resolvable after merge
+    source2 = {'ns.key': 'value'}
+
+    config = Configuration(source1, source2)
+
+    assert config.ns.key == config.ns.key2 == 'value'


### PR DESCRIPTION
Would

- crash during call to `_merge` if the reference is to be found outside the same source;
- cause value to be resolved during load, obscuring any value override from a potential 'later' source.

*Not* resolving keys during merge should resolve both bugs, leaving resolving of references to 'user-time'.