### PR TITLE
Restrict recursive reference pattern

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 development (master)
 --------------------
 
-
+- Restrict reference pattern to make a nested pattern work.
 
 0.6.2 (2019-11-25)
 ------------------

--- a/confidence/models.py
+++ b/confidence/models.py
@@ -30,7 +30,7 @@ class Configuration(Mapping):
     """
 
     # match a reference as ${key.to.be.resolved}
-    _reference_pattern = re.compile(r'\${(?P<path>[^}]+?)}')
+    _reference_pattern = re.compile(r'\${(?P<path>[^${}]+?)}')
 
     def __init__(self, *sources, separator='.', missing=Missing.silent):
         """

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -76,6 +76,18 @@ def test_multi_level_reference():
     assert config.key == 'A seemingly full, complete sentence.'
 
 
+def test_recursive_reference():
+    config = Configuration({
+        'ns': {'reference': 'final',
+               'final': 'the actual value'},
+        'wanted': '${ns.${ns.reference}}',
+    })
+
+    assert config.ns.final == 'the actual value'
+    assert config.ns.reference == 'final'
+    assert config.wanted == 'the actual value'
+
+
 def test_sub_config_reference():
     config = Configuration({
         'key': 'string',


### PR DESCRIPTION
Recursive references within the same value (e.g. `${reference.${within}.value}`) were broken due to the regular expression that matches a reference. While regular expressions aren't typically very good at recursive structures, this one seems workable with a small fix, making sure to only match the value not containing any of the reference syntax symbols. 

This might break somewhere unexpectedly in the future, but seems to not currently break any existing things :)