### PR TITLE
Wrap sequences to enable list-of-dicts style configurations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Changes
 development (master)
 --------------------
 
-
+- Auto-wrap configured sequences to enable 'list-of-dicts' style configuration while retaining `Configuration` functionality
 
 0.6.3 (2020-01-14)
 ------------------

--- a/confidence/models.py
+++ b/confidence/models.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from enum import Enum
 from itertools import chain
 import re
@@ -148,6 +148,8 @@ class Configuration(Mapping):
                 return as_type(value)
             elif isinstance(value, Mapping):
                 return self._wrap(value)
+            elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+                return _ConfigurationSequence(value, self._wrap)
             elif resolve_references and isinstance(value, str):
                 # only resolve references in str-type values (the only way they can be expressed)
                 return self._resolve(value)

--- a/confidence/models.py
+++ b/confidence/models.py
@@ -152,7 +152,7 @@ class Configuration(Mapping):
                 return self._wrap(value)
             elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
                 # wrap value in a sequence that retains Configuration functionality
-                return _ConfigurationSequence(value, self._wrap)
+                return ConfigurationSequence(value, self._wrap)
             elif resolve_references and isinstance(value, str):
                 # only resolve references in str-type values (the only way they can be expressed)
                 return self._resolve(value)
@@ -254,7 +254,7 @@ NotConfigured._missing = NotConfigured
 _COLLIDING_KEYS = frozenset(dir(Configuration()))
 
 
-class _ConfigurationSequence(Sequence):
+class ConfigurationSequence(Sequence):
     """
     A sequence of configured values, retrievable as if this were a `list`.
     """

--- a/confidence/models.py
+++ b/confidence/models.py
@@ -243,3 +243,22 @@ NotConfigured._missing = NotConfigured
 
 
 _COLLIDING_KEYS = frozenset(dir(Configuration()))
+
+
+class _ConfigurationSequence(Sequence):
+    def __init__(self, source, factory):
+        self._source = source
+        self._factory = factory
+
+    def __getitem__(self, item):
+        # TODO: deal with item being a slice
+        value = self._source[item]
+        if isinstance(value, Mapping):
+            return self._factory(value)
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            return type(self)(value, self._factory)
+        else:
+            return value
+
+    def __len__(self):
+        return len(self._source)

--- a/tests/files/complicated.yaml
+++ b/tests/files/complicated.yaml
@@ -9,3 +9,16 @@ a:
     reference: ${a.complicated}
   complicated.reference: value with ${a.complicated.2019.a} reference in it
   '2019-03-28': 2019-03-28
+
+different.types:
+  - a string
+  - true
+  - 42.0
+  - also: a mapping
+    containing:
+      multiple: keys, just to make it more complicated
+      surprise:
+        - another
+        - sequence_with: a mapping inside it, with ${a.complicated.2019.a} reference (mind = blown)
+  - maybe: another mapping, for fun
+  - [1, 2, 3, 4]

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from unittest.mock import patch
 
 import pytest
@@ -29,7 +29,7 @@ def test_value_types():
     assert isinstance(subject.an_int, int)
     assert isinstance(subject.a_float, float)
     assert isinstance(subject.a_boolean, bool)
-    assert isinstance(subject.a_list, list)
+    assert isinstance(subject.a_list, Sequence)
     assert isinstance(subject.we_must, Mapping)
 
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1,0 +1,42 @@
+from collections.abc import Mapping, Sequence
+from os import path
+
+import pytest
+
+from confidence import loadf
+
+
+test_files = path.join(path.dirname(__file__), 'files')
+
+
+@pytest.fixture
+def complicated_config():
+    return loadf(path.join(test_files, 'complicated.yaml'))
+
+
+def test_configured_sequence(complicated_config):
+    assert isinstance(complicated_config.different.types, Sequence)
+    assert complicated_config.different.types[0] == 'a string'
+    assert complicated_config.different.types[1] is True
+    assert complicated_config.different.types[2] == 42.0
+    assert complicated_config.different.types[5][0] == 1
+    assert complicated_config.different.types[5][3] == 4
+
+
+def test_sequence_mapping(complicated_config):
+    assert isinstance(complicated_config.different.types[3], Mapping)
+    assert complicated_config.different.types[3].also == 'a mapping'
+    assert isinstance(complicated_config.different.types[4], Mapping)
+    assert complicated_config.different.types[4].maybe == 'another mapping, for fun'
+
+
+def test_nested_sequence_mapping(complicated_config):
+    assert isinstance(complicated_config.different.types[3].containing.surprise, Sequence)
+    assert complicated_config.different.types[3].containing.surprise[0] == 'another'
+
+
+def test_deep_reference(complicated_config):
+    ns = complicated_config.different.types[3].containing.surprise[1]
+
+    assert isinstance(ns, Mapping)
+    assert ns.sequence_with == 'a mapping inside it, with a reference (mind = blown)'

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -40,3 +40,12 @@ def test_deep_reference(complicated_config):
 
     assert isinstance(ns, Mapping)
     assert ns.sequence_with == 'a mapping inside it, with a reference (mind = blown)'
+
+
+def test_sequence_slice(complicated_config):
+    sequence = complicated_config.different.types[1:4]
+
+    assert len(sequence) == 3
+    assert sequence[0] is True
+    assert sequence[1] == 42.0
+    assert sequence[2].also == 'a mapping'


### PR DESCRIPTION
Wraps sequences in `Configuration` with a 'thin' wrapper that calls back to a `Configuration` instance for mapping values and calls 'itself' for sequence values. 

References #51.